### PR TITLE
Correct filename in library.properties includes field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Depends on the CAN library.
 category=Communication
 url=https://github.com/sandeepmistry/arduino-OBD2
 architectures=*
-includes=ODB2.h
+includes=OBD2.h


### PR DESCRIPTION
The correct filename is OBD2.h, not ODB2.h.