### PR TITLE
Added function to clear diagnostic trouble codes (DTC)

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -24,6 +24,7 @@ pidReadRaw	KEYWORD2
 vinRead	KEYWORD2
 ecuNameRead	KEYWORD2
 setTimeout	KEYWORD2
+clearAllStoredDTC   KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/OBD2.cpp
+++ b/src/OBD2.cpp
@@ -707,8 +707,7 @@ int OBD2Class::clearAllStoredDTC() {
     for (int retries = 10; retries > 0; retries--) {
         if (_useExtendedAddressing) {
             CAN.beginExtendedPacket(0x18db33f1, 8);
-        }
-        else {
+} else {
             CAN.beginPacket(0x7df, 8);
         }
         CAN.write(0x00); // number of additional bytes

--- a/src/OBD2.cpp
+++ b/src/OBD2.cpp
@@ -695,6 +695,36 @@ int OBD2Class::supportedPidsRead()
   return 1;
 }
 
+int OBD2Class::clearAllStoredDTC() {
+    //Function clears stored Diagnostic Trouble Codes (DTC)
+
+    // make sure at least 60 ms have passed since the last response
+    unsigned long lastResponseDelta = millis() - _lastPidResponseMillis;
+    if (lastResponseDelta < 60) {
+        delay(60 - lastResponseDelta);
+    }
+
+    for (int retries = 10; retries > 0; retries--) {
+        if (_useExtendedAddressing) {
+            CAN.beginExtendedPacket(0x18db33f1, 8);
+        }
+        else {
+            CAN.beginPacket(0x7df, 8);
+        }
+        CAN.write(0x00); // number of additional bytes
+        CAN.write(0x04); // Mode / Service 4, for clearing DTC
+        if (CAN.endPacket()) {
+            // send success
+            break;
+        }
+        else if (retries <= 1) {
+            return 0;
+        }
+    }
+
+    return 0;
+}
+
 int OBD2Class::pidRead(uint8_t mode, uint8_t pid, void* data, int length)
 {
   // make sure at least 60 ms have passed since the last response

--- a/src/OBD2.cpp
+++ b/src/OBD2.cpp
@@ -716,7 +716,7 @@ int OBD2Class::clearAllStoredDTC()
         if (CAN.endPacket()) {
             // send success
             break;
-} else if (retries <= 1) {
+        } else if (retries <= 1) {
             return 0;
         }
     }

--- a/src/OBD2.cpp
+++ b/src/OBD2.cpp
@@ -715,8 +715,7 @@ int OBD2Class::clearAllStoredDTC() {
         if (CAN.endPacket()) {
             // send success
             break;
-        }
-        else if (retries <= 1) {
+} else if (retries <= 1) {
             return 0;
         }
     }

--- a/src/OBD2.cpp
+++ b/src/OBD2.cpp
@@ -708,7 +708,7 @@ int OBD2Class::clearAllStoredDTC()
     for (int retries = 10; retries > 0; retries--) {
         if (_useExtendedAddressing) {
             CAN.beginExtendedPacket(0x18db33f1, 8);
-} else {
+        } else {
             CAN.beginPacket(0x7df, 8);
         }
         CAN.write(0x00); // number of additional bytes

--- a/src/OBD2.cpp
+++ b/src/OBD2.cpp
@@ -695,7 +695,8 @@ int OBD2Class::supportedPidsRead()
   return 1;
 }
 
-int OBD2Class::clearAllStoredDTC() {
+int OBD2Class::clearAllStoredDTC()
+{
     //Function clears stored Diagnostic Trouble Codes (DTC)
 
     // make sure at least 60 ms have passed since the last response

--- a/src/OBD2.h
+++ b/src/OBD2.h
@@ -131,6 +131,8 @@ public:
 
   void setTimeout(unsigned long timeout);
 
+  int clearAllStoredDTC();
+
 private:
   int supportedPidsRead();
 


### PR DESCRIPTION
Created function to clear DTC codes from vehicle ECU using Service 04 functionality, using format documented at:

https://en.wikipedia.org/wiki/OBD-II_PIDs#Service_04
https://en.wikipedia.org/wiki/OBD-II_PIDs#Query

ECU should return 0 data bytes.  PID not required.  This is part of Open Issue #5 