### PR TITLE
Added way to check if OBD is ready for another request

### DIFF
--- a/src/OBD2.cpp
+++ b/src/OBD2.cpp
@@ -795,4 +795,16 @@ int OBD2Class::pidRead(uint8_t mode, uint8_t pid, void* data, int length)
   return 0;
 }
 
+bool OBD2Class::ready()
+{
+  // make sure at least 60 ms have passed since the last response
+  unsigned long lastResponseDelta = millis() - _lastPidResponseMillis;
+
+  if (lastResponseDelta < 60) {
+    return false;
+  }
+
+  return true;
+}
+
 OBD2Class OBD2;

--- a/src/OBD2.h
+++ b/src/OBD2.h
@@ -133,6 +133,8 @@ public:
 
   int clearAllStoredDTC();
 
+  bool ready();
+
 private:
   int supportedPidsRead();
 


### PR DESCRIPTION
Great library and super useful.

I have a modified version I use to ensure the lib never blocks with delays. But I think this fix is good to have upstream to allow a simple check before entering a read. It does not do away with delays when reading large packets but is a step in the right direction. (I use a modified pidRead that returns a constant until it has all the responses to prevent delay, but that's for a different time)